### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Go Build and Test
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/deweb-services/terraform-provider-nodeshift/security/code-scanning/2](https://github.com/deweb-services/terraform-provider-nodeshift/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow file `.github/workflows/ci.yml`. This block should be placed at the top level (before `jobs:`) so that it applies to all jobs in the workflow unless overridden. The permissions should be set to the minimum required for the workflow to function correctly. Based on the workflow steps, the jobs require `contents: read` (for checking out code) and `issues: write` (for creating comments on issues via the GitHub API). No other permissions appear necessary. The change should be made by inserting the following block after the workflow `name:` and before the `on:` block:

```yaml
permissions:
  contents: read
  issues: write
```

No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
