### PR TITLE
feat: dws-5953 added api_url and with insecure to provider parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ terraform init && terraform apply
 make docker-build # example output:  "path for local bin is <path>/terraform-provider-nodeshift/bin/"
 nano $HOME/.terraformrc # with output path above and with config below
 terraform init
-NODESHIFT_TERRAFORM_API_URL=<desired http/https path> terraform apply -auto-approve
+NODESHIFT_TERRAFORM_API_ENDPOINT=<desired http/https path> terraform apply -auto-approve
 ```
 
 To make this plugin work locally, after the installation rename the binary file to

--- a/nodeshift/provider/client/client.go
+++ b/nodeshift/provider/client/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	APIURL = "https://app.nodeshift.com"
+	DefaultAPIEndpoint = "https://app.nodeshift.com"
 
 	defaultTimeoutSeconds = 120
 
@@ -51,6 +51,8 @@ type NodeshiftProviderConfiguration struct {
 	Profile               string
 	S3Endpoint            string
 	S3Region              string
+	APIEndpoint           string
+	Insecure              bool
 }
 
 type TaskResponse struct {
@@ -74,6 +76,7 @@ func (dc *NodeshiftProviderConfiguration) FromSlice(values []string) {
 	dc.Profile = values[3]
 	dc.S3Endpoint = values[4]
 	dc.S3Region = values[5]
+	dc.APIEndpoint = values[6]
 }
 
 func (c *NodeshiftClient) SetGlobalTransactionNote(note string) {
@@ -99,9 +102,15 @@ func NewClient(ctx context.Context, configuration NodeshiftProviderConfiguration
 
 	c := &NodeshiftClient{
 		Config: configuration,
-		client: &http.Client{},
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+				},
+			},
+		},
 		signer: signer,
-		url:    APIURL,
+		url:    DefaultAPIEndpoint,
 	}
 
 	if configuration.Timeout == 0 {
@@ -115,7 +124,7 @@ func NewClient(ctx context.Context, configuration NodeshiftProviderConfiguration
 	return c
 }
 
-func (c *NodeshiftClient) DoRequest(ctx context.Context, req *http.Request) ([]byte, error) {
+func (c *NodeshiftClient) doRequest(req *http.Request) ([]byte, error) {
 	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %w", err)
@@ -149,7 +158,7 @@ func (c *NodeshiftClient) DoSignedRequest(ctx context.Context, method string, en
 		return nil, err
 	}
 
-	return c.DoRequest(ctx, req)
+	return c.doRequest(req)
 }
 
 func checkResponse(res *http.Response) error {
@@ -177,20 +186,30 @@ func ClientOptWithS3() ClientOpt {
 	}
 }
 
-func (c *NodeshiftClient) newAwsClient() error {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
+func ClientOptWithInsecure() ClientOpt {
+	return func(c *NodeshiftClient) {
+		if c.client == nil {
+			return
+		}
+
+		c.client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				// nolint: gosec
+				InsecureSkipVerify: true,
+			},
+		}
 	}
-	httpCli := &http.Client{Transport: tr}
+}
+
+func (c *NodeshiftClient) newAwsClient() error {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return fmt.Errorf("s3 load deafault config error: %w", err)
 	}
+
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.Region = c.Config.S3Region
-		o.HTTPClient = httpCli
+		o.HTTPClient = c.client
 		o.Credentials = credentials.NewStaticCredentialsProvider(c.Config.AccessKey,
 			c.Config.SecretAccessKey, "")
 		o.BaseEndpoint = aws.String(c.Config.S3Endpoint)

--- a/nodeshift/provider/client/client_test.go
+++ b/nodeshift/provider/client/client_test.go
@@ -140,7 +140,7 @@ func TestNodeshiftClient_DoRequest(t *testing.T) {
 				client: &http.Client{},
 				signer: &Signer{},
 			}
-			got, err := c.DoRequest(context.Background(), tt.args.req)
+			got, err := c.doRequest(tt.args.req)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 
@@ -307,6 +307,7 @@ func TestNodeshiftProviderConfiguration_FromSlice(t *testing.T) {
 		Profile               string
 		S3Endpoint            string
 		S3Region              string
+		APIEndpoint           string
 	}
 	type args struct {
 		values []string
@@ -325,9 +326,10 @@ func TestNodeshiftProviderConfiguration_FromSlice(t *testing.T) {
 				Profile:               "profile",
 				S3Endpoint:            "s3_endpoint",
 				S3Region:              "s3_region",
+				APIEndpoint:           "api_endpoint",
 			},
 			args: args{
-				values: []string{"a_key", "s_key", "s_file", "profile", "s3_endpoint", "s3_region"},
+				values: []string{"a_key", "s_key", "s_file", "profile", "s3_endpoint", "s3_region", "api_endpoint"},
 			},
 		},
 		{
@@ -339,6 +341,7 @@ func TestNodeshiftProviderConfiguration_FromSlice(t *testing.T) {
 				Profile:               "profile",
 				S3Endpoint:            "s3_endpoint",
 				S3Region:              "s3_region",
+				APIEndpoint:           "api_url",
 			},
 			args: args{
 				values: []string{},

--- a/nodeshift/provider/client/interfaces.go
+++ b/nodeshift/provider/client/interfaces.go
@@ -3,13 +3,11 @@ package client
 import (
 	"context"
 	"io"
-	"net/http"
 )
 
 //go:generate mockgen -source interfaces.go -destination=./interfaces_mocks.go -package=client
 
 type INodeshiftClient interface {
-	DoRequest(ctx context.Context, req *http.Request) ([]byte, error)
 	DoSignedRequest(ctx context.Context, method string, endpoint string, body io.ReadSeeker) ([]byte, error)
 	SetGlobalTransactionNote(note string)
 

--- a/nodeshift/provider/client/interfaces_mocks.go
+++ b/nodeshift/provider/client/interfaces_mocks.go
@@ -12,7 +12,6 @@ package client
 import (
 	context "context"
 	io "io"
-	http "net/http"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -185,21 +184,6 @@ func (m *MockINodeshiftClient) DeleteVPC(ctx context.Context, id string) error {
 func (mr *MockINodeshiftClientMockRecorder) DeleteVPC(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVPC", reflect.TypeOf((*MockINodeshiftClient)(nil).DeleteVPC), ctx, id)
-}
-
-// DoRequest mocks base method.
-func (m *MockINodeshiftClient) DoRequest(ctx context.Context, req *http.Request) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoRequest", ctx, req)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DoRequest indicates an expected call of DoRequest.
-func (mr *MockINodeshiftClientMockRecorder) DoRequest(ctx, req any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoRequest", reflect.TypeOf((*MockINodeshiftClient)(nil).DoRequest), ctx, req)
 }
 
 // DoSignedRequest mocks base method.

--- a/nodeshift/provider/const.go
+++ b/nodeshift/provider/const.go
@@ -8,6 +8,8 @@ const (
 	Profile               = "profile"
 	S3Endpoint            = "s3_endpoint"
 	S3Region              = "s3_region"
+	APIEndpoint           = "api_endpoint"
+	WithInsecure          = "with_insecure"
 )
 
 const (
@@ -17,5 +19,5 @@ const (
 	EnvKeyProfile               = "NODESHIFT_PROFILE"
 	EnvKeyS3Endpoint            = "NODESHIFT_S3_ENDPOINT"
 	EnvKeyS3Region              = "NODESHIFT_S3_REGION"
-	EnvKeyAPIURL                = "NODESHIFT_TERRAFORM_API_URL"
+	EnvKeyAPIENDPOINT           = "NODESHIFT_TERRAFORM_API_ENDPOINT"
 )

--- a/nodeshift/provider/model.go
+++ b/nodeshift/provider/model.go
@@ -12,4 +12,7 @@ type nodeshiftProviderModel struct {
 
 	S3Endpoint types.String `tfsdk:"s3_endpoint"`
 	S3Region   types.String `tfsdk:"s3_region"`
+
+	APIEndpoint  types.String `tfsdk:"api_endpoint"`
+	WithInsecure types.Bool   `tfsdk:"with_insecure"`
 }

--- a/nodeshift/provider/provider.go
+++ b/nodeshift/provider/provider.go
@@ -71,6 +71,14 @@ func (p *nodeshiftProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				Description: "Nodeshift s3 region",
 				Optional:    true,
 			},
+			APIEndpoint: schema.StringAttribute{
+				Description: "Nodeshift API endpoint address",
+				Optional:    true,
+			},
+			WithInsecure: schema.BoolAttribute{
+				Description: "Nodeshift insecure connection",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -85,6 +93,7 @@ func (p *nodeshiftProvider) Configure(ctx context.Context, req provider.Configur
 	profile := os.Getenv(EnvKeyProfile)
 	s3Endpoint := os.Getenv(EnvKeyS3Endpoint)
 	s3Region := os.Getenv(EnvKeyS3Region)
+	ae := os.Getenv(EnvKeyAPIENDPOINT)
 
 	values := []string{
 		accessKey,
@@ -93,6 +102,7 @@ func (p *nodeshiftProvider) Configure(ctx context.Context, req provider.Configur
 		profile,
 		s3Endpoint,
 		s3Region,
+		ae,
 	}
 
 	// Retrieve provider data from configuration
@@ -133,6 +143,10 @@ func (p *nodeshiftProvider) Configure(ctx context.Context, req provider.Configur
 		values[5] = config.S3Region.ValueString()
 	}
 
+	if config.APIEndpoint.ValueString() != "" {
+		values[6] = config.APIEndpoint.ValueString()
+	}
+
 	type Attribute struct {
 		EnvName  string
 		Param    *types.String
@@ -168,6 +182,11 @@ func (p *nodeshiftProvider) Configure(ctx context.Context, req provider.Configur
 		S3Region: {
 			EnvName:  EnvKeyS3Region,
 			Param:    &config.S3Region,
+			Required: false,
+		},
+		APIEndpoint: {
+			EnvName:  EnvKeyAPIENDPOINT,
+			Param:    &config.APIEndpoint,
 			Required: false,
 		},
 	}
@@ -217,15 +236,19 @@ func (p *nodeshiftProvider) Configure(ctx context.Context, req provider.Configur
 	tflog.Debug(ctx, "Creating Nodeshift client")
 	var cfg client.NodeshiftProviderConfiguration
 	cfg.FromSlice(values)
+	cfg.Insecure = config.WithInsecure.ValueBool()
 	tflog.Debug(ctx, fmt.Sprintf("%+v", values))
 
-	url := os.Getenv(EnvKeyAPIURL)
-	if url == "" {
-		url = client.APIURL
+	opts := []client.ClientOpt{client.ClientOptWithS3()}
+	if cfg.APIEndpoint != "" {
+		opts = append(opts, client.ClientOptWithURL(cfg.APIEndpoint))
+	}
+	if cfg.Insecure {
+		opts = append(opts, client.ClientOptWithInsecure())
 	}
 
 	// Create a new nodeshift client using the configuration values
-	cli := client.NewClient(ctx, cfg, client.ClientOptWithURL(url), client.ClientOptWithS3())
+	cli := client.NewClient(ctx, cfg, opts...)
 	// Make the nodeshift client available during DataSource and Resource
 	resp.DataSourceData = cli
 	resp.ResourceData = cli


### PR DESCRIPTION
- provider parameter: api_endpoint
- provider parameter: with_insecure
- updated env variables
- updated readme

provider file example:
```
# Define providers and set versions
terraform {
  required_providers {
    nodeshift = {
      source = "deweb-services/nodeshift"
    }
  }
}

provider "nodeshift" {
  api_endpoint = "https://appp.nodeshift.com"
  with_insecure = true
}


